### PR TITLE
Made the property "id" serialize into a JSON object to send.

### DIFF
--- a/main/Smartsheet/Api/Internal/Json/ContractResolver.cs
+++ b/main/Smartsheet/Api/Internal/Json/ContractResolver.cs
@@ -33,10 +33,11 @@ namespace Smartsheet.Api.Internal.Json
 		protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
 		{
 				JsonProperty property = base.CreateProperty(member, memberSerialization);
-				if (property.PropertyName.ToLower().Equals("id"))
-				{
-					 property.ShouldSerialize = (object instance) => false;
-				}
+				//This below will not serialize the property "id" unless commented out.
+				//if (property.PropertyName.ToLower().Equals("id"))
+				//{
+				//	 property.ShouldSerialize = (object instance) => false;
+				//}
 				return property;
 		}
 


### PR DESCRIPTION
"id" did not serialize because of this contract resolver method.
"id" was made not to serialize before because "id" would be extracted
from the object and put into the request url. Now, due to operations
such as bulk-insert operations, "id" properties are required to be
present in the JSON object request as well as in the url.