### PR TITLE
Upgrading to Restsharp 105.2.3

### DIFF
--- a/Smartsheet-csharp-sdk.csproj
+++ b/Smartsheet-csharp-sdk.csproj
@@ -59,9 +59,9 @@
       <HintPath>packages\NUnitTestAdapter.2.0.0\lib\NUnit.VisualStudio.TestAdapter.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="RestSharp, Version=105.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>packages\RestSharp.105.1.0\lib\net4\RestSharp.dll</HintPath>
+      <HintPath>packages\RestSharp.105.2.3\lib\net4\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/main/Smartsheet/Api/Internal/Util/QueryUtil.cs
+++ b/main/Smartsheet/Api/Internal/Util/QueryUtil.cs
@@ -1,4 +1,4 @@
-﻿using RestSharp.Contrib;
+﻿using RestSharp.Extensions.MonoHttp;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/packages.config
+++ b/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net40" />
   <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net40" />
-  <package id="RestSharp" version="105.1.0" targetFramework="net40" />
+  <package id="RestSharp" version="105.2.3" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Restsharp had some namespace changes in version 105.2.2, which made it
impossible to use version 2.0.2 of this library (which is published on
NuGet) together with the latest stable version of Restsharp. The code
changes in this pull request makes this library compatible with the
latest stable version of Restsharp.