### PR TITLE
Add README development setup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ The SDK has been successfully developed on both Visual Studio 2015 and 2017 (Com
 
 The documentation requires the [Sandcastle Help File Builder](https://github.com/EWSoftware/SHFB/releases) and its Visual Studio extension to build; these dependencies should be optional, and Visual Studio will merely warn you and leave the documentation project unloaded if you don't have it installed.
 
+### Testing
+The project `TestSDKMockAPI` contains tests that execute against the [Mock API](https://github.com/smartsheet-platform/smartsheet-sdk-tests).
+
+The project `IntegrationTestSDK` contains tests that execute against the live API, using the credentials found in your environment. _Running these tests will make changes to the Smartsheet account running the tests_.
+
 ## Support
 If you have any questions or issues with this SDK please post on [StackOverflow using the tag "smartsheet-api"](http://stackoverflow.com/questions/tagged/smartsheet-api) or contact us directly at api@smartsheet.com.
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ The generated SDK class documentation is here: [http://smartsheet-platform.githu
 ## Contributing
 If you would like to contribute a change to the SDK, please fork a branch and then submit a pull request. [More info here.](https://help.github.com/articles/using-pull-requests)
 
+### Development Environment
+The SDK has been successfully developed on both Visual Studio 2015 and 2017 (Community Edition), on Windows 10 devices.
+
+The documentation requires the [Sandcastle Help File Builder](https://github.com/EWSoftware/SHFB/releases) and its Visual Studio extension to build; these dependencies should be optional, and Visual Studio will merely warn you and leave the documentation project unloaded if you don't have it installed.
+
 ## Support
 If you have any questions or issues with this SDK please post on [StackOverflow using the tag "smartsheet-api"](http://stackoverflow.com/questions/tagged/smartsheet-api) or contact us directly at api@smartsheet.com.
 


### PR DESCRIPTION
Tacked on some documentation on developing the SDK, mostly providing tips for setting up the Sandcastle tool and running tests.