### PR TITLE
Fixed double url escaping for the search api call

### DIFF
--- a/main/Smartsheet/Api/Internal/SearchResourcesImpl.cs
+++ b/main/Smartsheet/Api/Internal/SearchResourcesImpl.cs
@@ -117,7 +117,7 @@ namespace Smartsheet.Api.Internal
             {
                 parameters.Add("scopes", QueryUtil.GenerateCommaSeparatedList(scopes));
             }
-            parameters.Add("query", Uri.EscapeDataString(query));
+            parameters.Add("query", query);
             return this.GetResource<SearchResult>("search" + QueryUtil.GenerateUrl(null, parameters), typeof(SearchResult));
         }
 


### PR DESCRIPTION
This pull request solves the double url escaping problem in the sdk for the /search api call.
For example: in the current sdk version a space will turn into %2520, it should be %20.

Escaping for the search call is done in main/Smartsheet/Api/Internal/SearchResourcesImpl.cs and in smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/Util/QueryUtil.cs in the current sdk.