### PR TITLE
Add missing Access Scopes to AccessScopes enum

### DIFF
--- a/main/Smartsheet/Api/OAuth/AccessScope.cs
+++ b/main/Smartsheet/Api/OAuth/AccessScope.cs
@@ -94,6 +94,16 @@ namespace Smartsheet.Api.OAuth
         /// <summary>
         /// Create and manage workspaces and folders, including sharing
         /// </summary>
-        ADMIN_WORKSPACES
+        ADMIN_WORKSPACES,
+        
+        /// <summary>
+        /// Modify dashboards structure.
+        /// </summary>
+        ADMIN_SIGHTS,
+        
+        /// <summary>
+        /// Create, delete, and update webhooks; get all webhooks; reset shared secret.
+        /// </summary>
+        ADMIN_WEBHOOKS
     }
 }


### PR DESCRIPTION
`ADMIN_SIGHTS` and `ADMIN_WEBHOOKS` are missing from the enum. I looked through references to the enum, and it looks like this change should work with no additional changes -- the OAuth module just calls `ToString` on them to translate them into the REST calls, so the name `ADMIN_SIGHTS` and `ADMIN_WEBHOOKS` will pass through just fine.

This fixes #127.